### PR TITLE
Update codeclimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,19 @@
-plugins: 
-  eslint:
+engines:
+  duplication:
     enabled: true
+    config:
+      languages:
+      - javascript
+  eslint:
+    channel: 'eslint-5'
+    config:
+      config: './.eslintrc'
+    enabled: true
+ratings:
+  paths:
+  - '**.js'
+exclude_paths:
+  - 'ios/'
+  - 'android/'
+  - 'assets/'
+  - '__tests__/'


### PR DESCRIPTION
This PR updates `codeclimate` to exclude rating files in `test`, `ios`, `assets` and `android` folder